### PR TITLE
Emit performance data

### DIFF
--- a/check_docker.go
+++ b/check_docker.go
@@ -311,8 +311,11 @@ func main() {
 	}
 
 	statuses := mapAlertStatuses(&info, opts)
-	baseStatus := nagios.NagiosStatus{float64String(info.Containers) + " containers", 0}
 
-	baseStatus.Aggregate(statuses)
-	nagios.ExitWithStatus(&baseStatus)
+	baseStatus := nagios.NagiosStatus{float64String(info.Containers) + " containers", 0}
+	perfdata := nagios.NagiosPerformanceVal{"containers", float64String(info.Containers), "", "", "", "", ""}
+	perfStatus := nagios.NagiosStatusWithPerformanceData{&baseStatus, perfdata}
+
+	perfStatus.Aggregate(statuses)
+	perfStatus.NagiosExit()
 }


### PR DESCRIPTION
Emit [performance data](http://docs.pnp4nagios.org/pnp-0.6/about#system_requirements) (see also [here](https://nagios-plugins.org/doc/guidelines.html#AEN200)) for consumption by Nagios pnp4graph. Changes the following normal output:

```
$ ./check_docker -base-url="http://localhost:1234"
OK: 1 containers
```

to this:

```
$ ./check_docker -base-url="http://localhost:1234"
OK: 1 containers | 'containers'=1;;;;
```

Requires go_nagios support https://github.com/newrelic/go_nagios/pull/1
