### PR TITLE
Add ability to check for container with given name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Testing for Contributors
 
 1. In Darwin(aufs), assuming you already setup Boot2Docker:
     ```
-    cd $GOPATH/src/github.com/newrelic/check_docker
-    docker run hello-world
-    export DOCKER_IMAGE=$(docker ps | grep busybox | awk '{print $2}')
+    docker run -t -d --name named_container busybox:latest
+    export DOCKER_IMAGE=busybox:latest
+    export DOCKER_CONTAINER_NAME=named_container
 
     cd $GOPATH/src/github.com/newrelic/check_docker
     go get ./... && go test
@@ -95,8 +95,9 @@ Testing for Contributors
     vagrant ssh
 
     # Inside Vagrant
-    sudo docker run hello-world
-    export DOCKER_IMAGE=$(sudo docker ps | grep busybox | awk '{print $2}')
+    sudo docker run -t -d --name named_container busybox:latest
+    export DOCKER_IMAGE=busybox:latest
+    export DOCKER_CONTAINER_NAME=named_container
 
     export GOPATH=/go
     cd $GOPATH/src/github.com/newrelic/check_docker

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Usage
 ```
 Usage of ./check_docker:
   -base-url="http://docker-server:2375": The Base URL for the Docker server
+  -container-name="": The name of a container that must be running on the Docker server
   -warn-data-space=100: Warning threshold for Data Space
   -crit-data-space=100: Critical threshold for Data Space
   -warn-meta-space=100: Warning threshold for Metadata Space
@@ -45,6 +46,9 @@ Usage of ./check_docker:
 ```
 
 `-base-url`: Here you specify the base url of the docker server.
+
+`-container-name`: Allows you to specify the name of a container that should be running
+on the server.
 
 `-image-id`: You can specify an image tag that needs to be running on the server for
 certain cases where you have pegged a container to a server (e.g. each server

--- a/check_docker_test.go
+++ b/check_docker_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func init() {
-	if os.Getenv("DOCKER_IMAGE") == "" {
-		println("You must set DOCKER_IMAGE to test image related things.")
+	if os.Getenv("DOCKER_IMAGE") == "" || os.Getenv("DOCKER_CONTAINER_NAME") == "" {
+		println("You must set DOCKER_IMAGE and DOCKER_CONTAINER_NAME to test image related things.")
 	}
 }
 
@@ -102,6 +102,28 @@ func TestIsContainerRunning(t *testing.T) {
 	}
 }
 
+func TestIsNamedContainerRunning(t *testing.T) {
+	containerName := os.Getenv("DOCKER_CONTAINER_NAME")
+
+	if containerName == "" {
+		return
+	}
+
+	cd := NewCheckDockerForTest(t)
+	_, isRunning := cd.IsNamedContainerRunning(containerName)
+
+	if !isRunning {
+		t.Errorf("Container named: %v should be running.", containerName)
+	}
+
+	containerName = "no_container_with_this_name_should_exist"
+	_, isRunning = cd.IsNamedContainerRunning(containerName)
+
+	if isRunning {
+		t.Errorf("Container named: %v should not be running.", containerName)
+	}
+}
+
 func TestCountGhostsByImageId(t *testing.T) {
 	imageId := os.Getenv("DOCKER_IMAGE")
 
@@ -146,5 +168,23 @@ func TestCheckImageContainerIsInGoodShape(t *testing.T) {
 		if status.Value != 0 {
 			t.Errorf("Container of image: %v should be healthy.", imageId)
 		}
+	}
+}
+
+func TestCheckNamedContainerIsInGoodShape(t *testing.T) {
+	containerName := os.Getenv("DOCKER_CONTAINER_NAME")
+
+	if containerName == "" {
+		return
+	}
+
+	cd := NewCheckDockerForTest(t)
+	status := cd.CheckNamedContainerIsInGoodShape(containerName)
+
+	if status == nil {
+		t.Error("NagiosStatus struct should never be nil.")
+	}
+	if status.Value != 0 {
+		t.Errorf("Container named: %v should be healthy.", containerName)
 	}
 }


### PR DESCRIPTION
This adds a new argument, `-container-name`, which will make
check_docker check that a container with the specified name exists and
is running.

This is useful in cases where you use the same container more than once,
but wish to ensure all instances are up. For example, two wordpress
blogs using the container `wordpress` but named `wordpress_A` and
`wordpress_B`.